### PR TITLE
Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,18 +2,48 @@
 BIN = pushtf
 CC = gcc
 RM = rm -f
+CHECKSUM = md5sum
+INSTALL = install -m 0755
+
+# Paths
+CHECKSUMFILE = $(BIN).md5
+INSTALLPATH = /usr/local/bin
 
 # Compiler options
 CFLAGS = -D_FILE_OFFSET_BITS=64 -Wall -pedantic -fstack-protector -O2
 LDFLAGS = -lcurl
 
 # Rules name definition
-.PHONY: all clean
+.PHONY: all clean install uninstall reset
 
 # Rule: all
-all:
+all: $(BIN)
+
+# Rule: pushtf
+$(BIN): *.o
 	$(CC) *.c $(CFLAGS) $(LDFLAGS) -o $(BIN)
+
+# Build objects
+%.o: %.c
+	$(CC) $(CFLAGS) -c $<
+
+# Rule: checksum
+checksum:
+	$(CHECKSUM) $(BIN) | cut -d' ' -f1 > $(CHECKSUMFILE)
 
 # Rule: clean
 clean:
+	$(RM) *.o
+	$(RM) $(CHECKSUMFILE)
+
+# Rule: reset
+reset: clean
 	$(RM) $(BIN)
+
+# Rule: install
+install:
+	$(INSTALL) $(BIN) $(INSTALLPATH)
+
+# Rule: uninstall
+uninstall:
+	$(RM) $(INSTALLPATH)/$(BIN)

--- a/README.md
+++ b/README.md
@@ -10,9 +10,19 @@ Developement is in beta stage and many features are still in the pipe.
 ### Compilation
 Use the dedicated `Makefile` by running the command:
 ```shell
-make
+make && make clean
 ```
-or, if you want to compile it by yourself, use:
+
+If you want to install it on you file system, simply run:
+
+```shell
+make install
+```
+
+Note that it might require administrator privileges.
+
+
+If you want to compile it by yourself, use:
 
 ```shell
 gcc *.c -D_FILE_OFFSET_BITS=64 -Wall -lcurl -o pushtf


### PR DESCRIPTION
Hello !

This is the return of the Makefile.

Here the list of the improvements: 
- Use object files (.o) to ease the compilation
- Add a rule to install the bin
- Add a rule to uninstall the bin
- Add a rule to generate a md5 checksum of the compiled binary (related to the issue https://github.com/pushtf/pushtf-client/issues/2)

Note that it uses `md5sum`, feel free to change to sha1 or anything you prefer.
Also note that I chose `/usr/local/bin` as an install path, feel free to tweak as you wish !

Thanks
